### PR TITLE
[modify] 피드 페이지 css 수정 및 콘솔 에러/경고 일부 해결

### DIFF
--- a/src/components/layout/navigation/MypageNavigation.tsx
+++ b/src/components/layout/navigation/MypageNavigation.tsx
@@ -107,7 +107,7 @@ const SideMenuTextStyle = {
 };
 
 const SideMenuText = styled.button<{
-  variant: "clicked" | "unclicked";
+  $variant: "clicked" | "unclicked";
   isClicked: boolean;
 }>`
   display: flex;
@@ -137,7 +137,7 @@ const SideMenuPointStyle = {
 };
 
 const SideMenuPoint = styled.button<{
-  variant: "clicked" | "unclicked";
+  $variant: "clicked" | "unclicked";
   isClicked: boolean;
 }>`
   display: flex;
@@ -436,15 +436,15 @@ export default function MypageNavigation() {
           </UserTextWrapper>
           <ButtonWrapper>
             <ProfileButton
-              variant="friend"
+              $variant="friend"
               onClick={() => isModalOpen("friendModal")}
             >
               17명의 친구
             </ProfileButton>
-            <ProfileButton variant="diary" onClick={handleDiaryClick}>
+            <ProfileButton $variant="diary" onClick={handleDiaryClick}>
               {posts.length}개의 다이어리
             </ProfileButton>
-            <ProfileButton variant="mood" onClick={linkCalendar}>
+            <ProfileButton $variant="mood" onClick={linkCalendar}>
               97개의 무드
             </ProfileButton>
           </ButtonWrapper>
@@ -456,12 +456,12 @@ export default function MypageNavigation() {
             <SideMenu key={menu.key}>
               <SideMenuPoint
                 isClicked={activeMenu === menu.key}
-                variant="clicked"
+                $variant="clicked"
               />
               <Link to={menu.path}>
                 <SideMenuText
                   isClicked={activeMenu === menu.key}
-                  variant="clicked"
+                  $variant="clicked"
                   onClick={() => setActiveMenu(menu.key)}
                 >
                   {menu.label}

--- a/src/components/layout/navigation/Navigation.tsx
+++ b/src/components/layout/navigation/Navigation.tsx
@@ -44,24 +44,24 @@ const TextButtonGroup = styled.div`
   gap: clamp(0.25rem, 1vw, 0.75rem);
 `;
 
-const ImageButton = styled(Link)<{ variant: "home" | "post" | "calendar" }>`
+const ImageButton = styled(Link)<{ $variant: "home" | "post" | "calendar" }>`
   display: block;
   width: ${(props) =>
-    props.variant === "home"
+    props.$variant === "home"
       ? "clamp(1rem, 5vw, 2.5rem)"
-      : props.variant === "post"
+      : props.$variant === "post"
         ? "clamp(0.75rem, 4.5vw, 2.5rem)"
         : "clamp(0.75rem, 4.5vw, 2.5rem)"};
   height: ${(props) =>
-    props.variant === "home"
+    props.$variant === "home"
       ? "clamp(0.8rem, 4vw, 2.25rem)"
-      : props.variant === "post"
+      : props.$variant === "post"
         ? "clamp(0.6rem, 4vw, 2rem)"
         : "clamp(0.6rem, 4vw, 2rem)"};
   background-image: ${(props) =>
-    props.variant === "home"
+    props.$variant === "home"
       ? `url(${home})`
-      : props.variant === "post"
+      : props.$variant === "post"
         ? `url(${post})`
         : `url(${calendar})`};
   background-size: contain;
@@ -69,14 +69,14 @@ const ImageButton = styled(Link)<{ variant: "home" | "post" | "calendar" }>`
   background-position: center;
 `;
 
-const TextButton = styled.button<{ variant: "before" | "after" }>`
+const TextButton = styled.button<{ $variant: "before" | "after" }>`
   color: ${(props) =>
-    props.variant === "before"
+    props.$variant === "before"
       ? "var(--main-text)"
       : "var(--search-placeholder)"};
   font-size: clamp(0.75rem, 1.5vw, 1rem);
   font-weight: ${(props) =>
-    props.variant === "before" ? "var(--font-medium)" : "var(--font-regular)"};
+    props.$variant === "before" ? "var(--font-medium)" : "var(--font-regular)"};
   cursor: pointer;
 `;
 
@@ -193,15 +193,15 @@ export default function Navigation() {
           <LogoButton to="/" />
           <ButtonWrapper>
             <ImageButtonGroup>
-              <ImageButton variant="home" to="/" />
-              <ImageButton variant="post" to="/board/new" />
-              <ImageButton variant="calendar" to="/calendar" />
+              <ImageButton $variant="home" to="/" />
+              <ImageButton $variant="post" to="/board/new" />
+              <ImageButton $variant="calendar" to="/calendar" />
             </ImageButtonGroup>
             <TextButtonGroup>
-              <TextButton variant="after" onClick={handleMypage}>
+              <TextButton $variant="after" onClick={handleMypage}>
                 마이 페이지
               </TextButton>
-              <TextButton variant="after" onClick={handleLogout}>
+              <TextButton $variant="after" onClick={handleLogout}>
                 로그아웃
               </TextButton>
             </TextButtonGroup>
@@ -227,10 +227,10 @@ export default function Navigation() {
           <LogoButton to="/" />
           <ButtonWrapper>
             <TextButtonGroup>
-              <TextButton variant="before" onClick={handleLogin}>
+              <TextButton $variant="before" onClick={handleLogin}>
                 Login
               </TextButton>
-              <TextButton variant="before" onClick={handleSignUp}>
+              <TextButton $variant="before" onClick={handleSignUp}>
                 Signup
               </TextButton>
             </TextButtonGroup>

--- a/src/components/modal/BoardWriteModal.tsx
+++ b/src/components/modal/BoardWriteModal.tsx
@@ -1,92 +1,92 @@
-import styled from "styled-components"
-import signUpImg from "../../assets/images/signUp.svg"
-import { useIsModalStore } from "../../store/ModalStore"
-import { OrangeButton } from "../ui/Button"
+import styled from "styled-components";
+import signUpImg from "../../assets/images/signUp.svg";
+import { useIsModalStore } from "../../store/ModalStore";
+import { OrangeButton } from "../ui/Button";
 
 const BoardWriteWrap = styled.div`
-    width:36.5rem;
-    background-color:var(--bg-01);
-    border-radius:5rem;
-    padding-bottom:3.625rem;
+  width: 36.5rem;
+  background-color: var(--bg-01);
+  border-radius: 5rem;
+  padding-bottom: 3.625rem;
 
-    @media (max-width:781px){
-        width:29.5rem;
-    }
+  @media (max-width: 781px) {
+    width: 29.5rem;
+  }
 
-    @media (max-width:390px){
-        width:17.5rem;
-        margin:0 auto;
-        border-radius:2.5rem;
-        padding-top:2.375rem;
-        padding-bottom:1.875rem;
-    }
-`
+  @media (max-width: 390px) {
+    width: 17.5rem;
+    margin: 0 auto;
+    border-radius: 2.5rem;
+    padding-top: 2.375rem;
+    padding-bottom: 1.875rem;
+  }
+`;
 
 const Title = styled.div`
-    padding-top:4.125rem;
+  padding-top: 4.125rem;
 
-    > h2{
-        margin:0;
-        color:var(--main-orange);
-        font-size:2.25rem;
-        font-weight:var(--font-semibold);
-        padding-top:1.25rem;
-    }
+  > h2 {
+    margin: 0;
+    color: var(--main-orange);
+    font-size: 2.25rem;
+    font-weight: var(--font-semibold);
+    padding-top: 1.25rem;
+  }
 
-    > p{
-        margin:0; 
-        font-size:1.5rem;
-        font-weight:var(--font-medium);
-        padding-top:1.25rem;
-    }
-    > p:last-child{
-        font-size:1.125rem;
-        font-weight:var(--font-regular);
-        color:var(--text-03);
-        padding-bottom:1.75rem;
-    }
+  > p {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: var(--font-medium);
+    padding-top: 1.25rem;
+  }
+  > p:last-child {
+    font-size: 1.125rem;
+    font-weight: var(--font-regular);
+    color: var(--text-03);
+    padding-bottom: 1.75rem;
+  }
 
-    @media (max-width:390px){
-        padding:0;
-        
-        > p{
-            font-size:1.125rem;
-        }
-        > h2{
-            font-size:1.75rem;
-        }
-        > p:last-child{
-            font-size:0.875rem;
-        }
+  @media (max-width: 390px) {
+    padding: 0;
+
+    > p {
+      font-size: 1.125rem;
     }
-`
+    > h2 {
+      font-size: 1.75rem;
+    }
+    > p:last-child {
+      font-size: 0.875rem;
+    }
+  }
+`;
 
 const Button = styled.button`
-    font-size:1.25rem;
-    font-weight:var(--font-semibold);
+  font-size: 1.25rem;
+  font-weight: var(--font-semibold);
+`;
 
-`
+export default function BoardWriteModal() {
+  const setIsModalClick = useIsModalStore((state) => state.setIsModalClick);
+  const onClickCheck = () => {
+    setIsModalClick();
+  };
 
-export default function BoardWriteModal(){
-    
-    const setIsModalClick = useIsModalStore((state) => state.setIsModalClick); 
-    const onClickCheck = () => {
-        setIsModalClick();
-    }
-
-    return(
-        <>
-            <BoardWriteWrap>
-                <Title>
-                    <img src={signUpImg} alt="체크 이미지" />
-                    <p>다이어리 작성 완료!</p>
-                    <h2>50 P</h2>
-                    <p>포인트가 적립되었습니다.</p>
-                </Title>
-                <Button>
-                    <OrangeButton variant="confirm" onClick={onClickCheck}>확인</OrangeButton>
-                </Button>
-            </BoardWriteWrap>
-        </>
-    )
+  return (
+    <>
+      <BoardWriteWrap>
+        <Title>
+          <img src={signUpImg} alt="체크 이미지" />
+          <p>다이어리 작성 완료!</p>
+          <h2>50 P</h2>
+          <p>포인트가 적립되었습니다.</p>
+        </Title>
+        <Button>
+          <OrangeButton $variant="confirm" onClick={onClickCheck}>
+            확인
+          </OrangeButton>
+        </Button>
+      </BoardWriteWrap>
+    </>
+  );
 }

--- a/src/components/modal/ChangePasswordModal.tsx
+++ b/src/components/modal/ChangePasswordModal.tsx
@@ -88,7 +88,7 @@ export default function ChangePasswordModal() {
           <p>새로 로그인 해주세요.</p>
         </Title>
         <Button>
-          <OrangeButton variant="confirm" onClick={onClickCheck}>
+          <OrangeButton $variant="confirm" onClick={onClickCheck}>
             확인
           </OrangeButton>
         </Button>

--- a/src/components/modal/CommentWriteModal.tsx
+++ b/src/components/modal/CommentWriteModal.tsx
@@ -1,92 +1,93 @@
-import styled from "styled-components"
-import signUpImg from "../../assets/images/signUp.svg"
-import { useIsModalStore } from "../../store/ModalStore"
-import { OrangeButton } from "../ui/Button"
+import styled from "styled-components";
+import signUpImg from "../../assets/images/signUp.svg";
+import { useIsModalStore } from "../../store/ModalStore";
+import { OrangeButton } from "../ui/Button";
 
 const CommentWriteWrap = styled.div`
-    width:36.5rem;
-    background-color:var(--bg-01);
-    border-radius:5rem;
-    padding-bottom:3.625rem;
+  width: 36.5rem;
+  background-color: var(--bg-01);
+  border-radius: 5rem;
+  padding-bottom: 3.625rem;
 
-    @media (max-width:781px){
-        width:29.5rem;
-        border-radius:5rem;
-    }
+  @media (max-width: 781px) {
+    width: 29.5rem;
+    border-radius: 5rem;
+  }
 
-    @media (max-width:390px){
-        padding-bottom:1.875rem;
-        width:17.5rem;
-        margin:0 auto;
-        border-radius:2.5rem;
-    }
-`
+  @media (max-width: 390px) {
+    padding-bottom: 1.875rem;
+    width: 17.5rem;
+    margin: 0 auto;
+    border-radius: 2.5rem;
+  }
+`;
 
 const Title = styled.div`
-    padding-top:4.125rem;
+  padding-top: 4.125rem;
 
-    > h2{
-        margin:0;
-        padding-top:1.25rem;
-        color:var(--main-orange);
-        font-size:2.25rem;
-        font-weight:var(--font-semibold);
+  > h2 {
+    margin: 0;
+    padding-top: 1.25rem;
+    color: var(--main-orange);
+    font-size: 2.25rem;
+    font-weight: var(--font-semibold);
+  }
+
+  > p {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: var(--font-medium);
+    padding-top: 1.25rem;
+  }
+  > p:last-child {
+    font-size: 1.125rem;
+    font-weight: var(--font-regular);
+    color: var(--text-03);
+    padding-bottom: 1.75rem;
+  }
+
+  @media (max-width: 390px) {
+    padding-top: 2.375rem;
+
+    > p {
+      font-size: 1.125rem;
+    }
+    > p:last-child {
+      font-size: 0.875rem;
     }
 
-    > p{
-        margin:0; 
-        font-size:1.5rem;
-        font-weight:var(--font-medium);
-        padding-top:1.25rem;
+    > h2 {
+      font-size: 1.75rem;
     }
-    > p:last-child{
-        font-size:1.125rem;
-        font-weight:var(--font-regular);
-        color:var(--text-03);
-        padding-bottom:1.75rem;
-    }
-
-    @media (max-width:390px){
-        padding-top:2.375rem;
-        
-        > p{
-            font-size:1.125rem;
-        }
-        > p:last-child{
-            font-size:0.875rem;
-        }
-
-        > h2{
-            font-size:1.75rem;
-        }
-    }
-`
+  }
+`;
 
 const Button = styled.button`
-    font-size:1.25rem;
-    font-weight:var(--font-semibold);
-`
+  font-size: 1.25rem;
+  font-weight: var(--font-semibold);
+`;
 
-export default function CommentWriteModal(){
-    
-    const setIsModalClick = useIsModalStore((state) => state.setIsModalClick); 
-    const onClickCheck = () => {
-        setIsModalClick();
-    }
+export default function CommentWriteModal() {
+  const setIsModalClick = useIsModalStore((state) => state.setIsModalClick);
+  const onClickCheck = () => {
+    setIsModalClick();
+  };
 
-    return(
-        <>
-            <CommentWriteWrap>
-                <Title>
-                    <img src={signUpImg} alt="체크 이미지" />
-                    <p>댓글 작성 완료!</p>
-                    <h2>20 P</h2>
-                    <p>포인트가 적립되었습니다.</p>
-                </Title>
-                <Button>
-                    <OrangeButton variant="confirm" onClick={onClickCheck}>확인</OrangeButton>
-                </Button>
-            </CommentWriteWrap>
-        </>
-    )
+  return (
+    <>
+      <CommentWriteWrap>
+        <Title>
+          <img src={signUpImg} alt="체크 이미지" />
+          <p>댓글 작성 완료!</p>
+          <h2>20 P</h2>
+          <p>포인트가 적립되었습니다.</p>
+        </Title>
+        <Button>
+          <OrangeButton $variant="confirm" onClick={onClickCheck}>
+            확인
+          </OrangeButton>
+        </Button>
+      </CommentWriteWrap>
+    </>
+  );
 }

--- a/src/components/modal/DeleteCompleteModal.tsx
+++ b/src/components/modal/DeleteCompleteModal.tsx
@@ -82,7 +82,7 @@ export default function DeleteCompleteModal() {
           <p>회원 탈퇴가 정상적으로 처리되었습니다.</p>
         </Title>
         <Button>
-          <OrangeButton variant="confirm" onClick={onClickCheck}>
+          <OrangeButton $variant="confirm" onClick={onClickCheck}>
             확인
           </OrangeButton>
         </Button>

--- a/src/components/modal/DeleteIdCompleteModal.tsx
+++ b/src/components/modal/DeleteIdCompleteModal.tsx
@@ -82,7 +82,7 @@ export default function DeleteIdCompleteModal() {
           <p>회원 탈퇴가 정상적으로 처리되었습니다.</p>
         </Title>
         <Button>
-          <OrangeButton variant="confirm" onClick={onClickCheck}>
+          <OrangeButton $variant="confirm" onClick={onClickCheck}>
             확인
           </OrangeButton>
         </Button>

--- a/src/components/modal/DeleteIdModal.tsx
+++ b/src/components/modal/DeleteIdModal.tsx
@@ -73,10 +73,10 @@ export default function DeleteIdModal() {
           <p>정말로 탈퇴 하시겠습니까?</p>
         </Title>
         <Button>
-          <OrangeLineButton variant="modal" onClick={onClickCancel}>
+          <OrangeLineButton $variant="modal" onClick={onClickCancel}>
             취소
           </OrangeLineButton>
-          <OrangeButton variant="confirm">확인</OrangeButton>
+          <OrangeButton $variant="confirm">확인</OrangeButton>
         </Button>
       </DeleteIdWrap>
     </>

--- a/src/components/modal/DeleteModal.tsx
+++ b/src/components/modal/DeleteModal.tsx
@@ -86,10 +86,10 @@ export default function DeleteModal() {
           <p>300 포인트 차감됩니다.</p> {/* 회원탈퇴 모달에선 제거 */}
         </Title>
         <Button>
-          <OrangeLineButton variant="modal" onClick={onClickCancel}>
+          <OrangeLineButton $variant="modal" onClick={onClickCancel}>
             취소
           </OrangeLineButton>
-          <OrangeButton variant="confirm">확인</OrangeButton>
+          <OrangeButton $variant="confirm">확인</OrangeButton>
         </Button>
       </Wrap>
     </>

--- a/src/components/modal/DeleteThemeCompleteModal.tsx
+++ b/src/components/modal/DeleteThemeCompleteModal.tsx
@@ -68,7 +68,7 @@ export default function DeleteThemeCompleteModal() {
           <p>테마 삭제가 정상적으로 처리되었습니다.</p>
         </Title>
         <Button>
-          <OrangeButton variant="confirm" onClick={onClickCheck}>
+          <OrangeButton $variant="confirm" onClick={onClickCheck}>
             확인
           </OrangeButton>
         </Button>

--- a/src/components/modal/DeleteThemeModal.tsx
+++ b/src/components/modal/DeleteThemeModal.tsx
@@ -83,10 +83,10 @@ export default function DeleteThemeModal() {
           <p>삭제한 테마와 사용된 포인트는 복구되지 않습니다.</p>
         </Title>
         <Button>
-          <OrangeLineButton variant="modal" onClick={onClickCancel}>
+          <OrangeLineButton $variant="modal" onClick={onClickCancel}>
             취소
           </OrangeLineButton>
-          <OrangeButton variant="confirm">확인</OrangeButton>
+          <OrangeButton $variant="confirm">확인</OrangeButton>
         </Button>
       </DeleteThemaWrap>
     </>

--- a/src/components/modal/FindPasswordModal.tsx
+++ b/src/components/modal/FindPasswordModal.tsx
@@ -91,7 +91,7 @@ export default function FindPasswordModal() {
           <p>이메일을 통해 비밀번호 재설정 링크를 보내드려요.</p>
         </Title>
         <Input type="text" placeholder="example@meetda.com" />
-        <OrangeButton variant="mailSend">메일 전송하기</OrangeButton>
+        <OrangeButton $variant="mailSend">메일 전송하기</OrangeButton>
       </Wrap>
     </>
   );

--- a/src/components/modal/FriendModal.tsx
+++ b/src/components/modal/FriendModal.tsx
@@ -235,7 +235,7 @@ export default function FriendModal() {
                 onClick={() =>
                   setActiveTab(activeTab === menu.key ? "" : menu.key)
                 }
-                variant={activeTab === menu.key ? "clicked" : "unclicked"}
+                $variant={activeTab === menu.key ? "clicked" : "unclicked"}
               >
                 {menu.label}
               </FriendTabButton>
@@ -254,7 +254,7 @@ export default function FriendModal() {
                 <UserText>믿음소망사랑 아니고 사과</UserText>
               </FriendProfile>
               <FriendButton
-                variant={
+                $variant={
                   activeTab === "following" ? "diaryUnfollow" : "diaryFollow"
                 }
               >

--- a/src/components/modal/MoodTrackerModal.tsx
+++ b/src/components/modal/MoodTrackerModal.tsx
@@ -191,10 +191,10 @@ export default function MoodTrackerModal() {
           <Textarea maxLength={100} showCount />
         </TextAreaWrap>
         <ButtonWrap>
-          <RecordButton variant="moodCancel" onClick={CloseButton}>
+          <RecordButton $variant="moodCancel" onClick={CloseButton}>
             취소
           </RecordButton>
-          <RecordButton variant="moodSubmit">등록</RecordButton>
+          <RecordButton $variant="moodSubmit">등록</RecordButton>
         </ButtonWrap>
       </Wrap>
     </>

--- a/src/components/modal/NoticeModal.tsx
+++ b/src/components/modal/NoticeModal.tsx
@@ -86,7 +86,7 @@ export default function NoticeModal() {
           <p>로그인 하시겠습니까?</p>
         </NoticeText>
         <Button>
-          <OrangeButton variant="signupToLogin" onClick={handleLogin}>
+          <OrangeButton $variant="signupToLogin" onClick={handleLogin}>
             로그인
           </OrangeButton>
         </Button>

--- a/src/components/modal/PointModal.tsx
+++ b/src/components/modal/PointModal.tsx
@@ -91,7 +91,7 @@ export default function PointModal() {
           <p>포인트가 적립되었습니다.</p>
         </Title>
         <Button>
-          <OrangeButton variant="confirm" onClick={onClickCheck}>
+          <OrangeButton $variant="confirm" onClick={onClickCheck}>
             확인
           </OrangeButton>
         </Button>

--- a/src/components/modal/PopularDiaryModal.tsx
+++ b/src/components/modal/PopularDiaryModal.tsx
@@ -92,7 +92,7 @@ export default function PopularDiaryModal() {
           <p>포인트가 적립되었습니다.</p>
         </Title>
         <Button>
-          <OrangeButton variant="confirm" onClick={onClickCheck}>
+          <OrangeButton $variant="confirm" onClick={onClickCheck}>
             확인
           </OrangeButton>
         </Button>

--- a/src/components/modal/SignUpModal.tsx
+++ b/src/components/modal/SignUpModal.tsx
@@ -87,8 +87,10 @@ export default function SignUpModal() {
           <p>로그인 후 믿다를 이용해보세요!</p>
         </Title>
         <Button>
-          <OrangeLineButton variant="moveToHome">🏠</OrangeLineButton>
-          <OrangeButton variant="signupToLogin" onClick={handleLogin}>로그인</OrangeButton>
+          <OrangeLineButton $variant="moveToHome">🏠</OrangeLineButton>
+          <OrangeButton $variant="signupToLogin" onClick={handleLogin}>
+            로그인
+          </OrangeButton>
         </Button>
       </Wrap>
     </>

--- a/src/components/modal/ThemeBuyModal.tsx
+++ b/src/components/modal/ThemeBuyModal.tsx
@@ -86,10 +86,10 @@ export default function ThemeBuyModal() {
           <p>300 포인트 차감됩니다.</p>
         </Title>
         <Button>
-          <OrangeLineButton variant="modal" onClick={onClickCancel}>
+          <OrangeLineButton $variant="modal" onClick={onClickCancel}>
             취소
           </OrangeLineButton>
-          <OrangeButton variant="confirm">확인</OrangeButton>
+          <OrangeButton $variant="confirm">확인</OrangeButton>
         </Button>
       </ThemaBuyWrap>
     </>

--- a/src/components/modal/TodayMood.tsx
+++ b/src/components/modal/TodayMood.tsx
@@ -1,87 +1,88 @@
-import styled from "styled-components"
-import CheckImg from "../../assets/images/signUp.svg"
-import { OrangeButton } from "../ui/Button"
-import { useIsModalStore } from "@/store/ModalStore"
+import styled from "styled-components";
+import CheckImg from "../../assets/images/signUp.svg";
+import { OrangeButton } from "../ui/Button";
+import { useIsModalStore } from "@/store/ModalStore";
 
 const AttendancePoint = styled.div`
-    width:36.5rem;
-    background-color:var(--bg-01);
-    border-radius:5rem;
-    padding-top:3.375rem;
-    padding-bottom:3.5rem;
+  width: 36.5rem;
+  background-color: var(--bg-01);
+  border-radius: 5rem;
+  padding-top: 3.375rem;
+  padding-bottom: 3.5rem;
 
-    @media (max-width:390px){
-        width:20rem;
-        margin:0 auto;
-        border-radius:2.5rem;
-        padding-top:2.375rem;
-        padding-bottom:1.875rem;
-    }
-`
+  @media (max-width: 390px) {
+    width: 20rem;
+    margin: 0 auto;
+    border-radius: 2.5rem;
+    padding-top: 2.375rem;
+    padding-bottom: 1.875rem;
+  }
+`;
 
 const Title = styled.div`
+  > p {
+    margin: 0;
+    font-size: 1.5rem;
+    padding-top: 1.25rem;
+  }
+  > p:last-child {
+    font-size: 1.125rem;
+    color: var(--text-03);
+    padding: 0;
+  }
 
-    > p{
-        margin:0;
-        font-size:1.5rem;
-        padding-top:1.25rem;
-    }
-    > p:last-child{
-        font-size:1.125rem;
-        color:var(--text-03);
-        padding:0;
-    }
+  > h2 {
+    margin: 0;
+    font-size: 2.25rem;
+    color: var(--main-orange);
+    padding: 1.25rem 0;
+  }
 
-    > h2{
-        margin:0;
-        font-size:2.25rem;
-        color:var(--main-orange);
-        padding:1.25rem 0;
+  @media (max-width: 390px) {
+    > h2 {
+      font-size: 1.75rem;
     }
-
-    @media (max-width:390px){
-        > h2{
-            font-size:1.75rem;
-        }
-        > p{
-            padding-top:1.25rem;
-        }
-        > p:last-child{
-            font-size:1rem;
-        }
+    > p {
+      padding-top: 1.25rem;
     }
-`
+    > p:last-child {
+      font-size: 1rem;
+    }
+  }
+`;
 
 const Button = styled.div`
-    margin-top:1.75rem;
-    height:3.5rem;
-    display:flex;
-    justify-content:center;
+  margin-top: 1.75rem;
+  height: 3.5rem;
+  display: flex;
+  justify-content: center;
 
-    > button{
-        height:3.5rem;
-    }
-`
+  > button {
+    height: 3.5rem;
+  }
+`;
 
-export default function TodayMoodModal(){
-    const setIsModalClick = useIsModalStore((state) => state.setIsModalClick); 
-    const onClickCheck = () => {
-        setIsModalClick();
-    }
+export default function TodayMoodModal() {
+  const setIsModalClick = useIsModalStore((state) => state.setIsModalClick);
+  const onClickCheck = () => {
+    setIsModalClick();
+  };
 
-    return(
-        <>
-            <AttendancePoint>
-                <Title>
-                    <img src={CheckImg} alt="체크 이미지" />
-                    <p>오늘의 무드 기록 완료!</p>
-                    <h2>10 P</h2>
-                    <p>포인트가 적립되었습니다.</p>
-                </Title>
-                <Button>
-                    <OrangeButton variant="confirm" onClick={onClickCheck}>확인</OrangeButton>
-                </Button>
-            </AttendancePoint>
-        </>
-    )
+  return (
+    <>
+      <AttendancePoint>
+        <Title>
+          <img src={CheckImg} alt="체크 이미지" />
+          <p>오늘의 무드 기록 완료!</p>
+          <h2>10 P</h2>
+          <p>포인트가 적립되었습니다.</p>
+        </Title>
+        <Button>
+          <OrangeButton $variant="confirm" onClick={onClickCheck}>
+            확인
+          </OrangeButton>
+        </Button>
+      </AttendancePoint>
+    </>
+  );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -160,7 +160,7 @@ const FriendButtonStyle = {
 };
 
 export const FriendButton = styled.button<{
-  variant:
+  $variant:
     | "follow"
     | "unfollow"
     | "diaryFollow"
@@ -171,30 +171,30 @@ export const FriendButton = styled.button<{
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${(props) => FriendButtonStyle[props.variant].default.width};
-  height: ${(props) => FriendButtonStyle[props.variant].default.height};
+  width: ${(props) => FriendButtonStyle[props.$variant].default.width};
+  height: ${(props) => FriendButtonStyle[props.$variant].default.height};
   background-color: none;
-  border: ${(props) => FriendButtonStyle[props.variant].default.border};
+  border: ${(props) => FriendButtonStyle[props.$variant].default.border};
   border-radius: ${(props) =>
-    FriendButtonStyle[props.variant].default.borderRadius};
-  color: ${(props) => FriendButtonStyle[props.variant].default.color};
+    FriendButtonStyle[props.$variant].default.borderRadius};
+  color: ${(props) => FriendButtonStyle[props.$variant].default.color};
   text-align: center;
-  font-size: ${(props) => FriendButtonStyle[props.variant].default.fontSize};
+  font-size: ${(props) => FriendButtonStyle[props.$variant].default.fontSize};
   font-weight: var(--font-semibold);
 
   &:hover {
-    background-color: ${({ variant }) => {
+    background-color: ${({ $variant }) => {
       if (
-        variant === "follow" ||
-        variant === "diaryFollow" ||
-        variant === "modalFollow"
+        $variant === "follow" ||
+        $variant === "diaryFollow" ||
+        $variant === "modalFollow"
       ) {
         return "var(--hover-green)";
       }
       if (
-        variant === "unfollow" ||
-        variant === "diaryUnfollow" ||
-        variant === "modalUnfollow"
+        $variant === "unfollow" ||
+        $variant === "diaryUnfollow" ||
+        $variant === "modalUnfollow"
       ) {
         return "var(--hover-orange)";
       }
@@ -202,19 +202,19 @@ export const FriendButton = styled.button<{
   }
 
   @media (max-width: 781px) {
-    width: ${(props) => FriendButtonStyle[props.variant].tablet.width};
-    height: ${(props) => FriendButtonStyle[props.variant].tablet.height};
+    width: ${(props) => FriendButtonStyle[props.$variant].tablet.width};
+    height: ${(props) => FriendButtonStyle[props.$variant].tablet.height};
     border-radius: ${(props) =>
-      FriendButtonStyle[props.variant].tablet.borderRadius};
-    font-size: ${(props) => FriendButtonStyle[props.variant].tablet.fontSize};
+      FriendButtonStyle[props.$variant].tablet.borderRadius};
+    font-size: ${(props) => FriendButtonStyle[props.$variant].tablet.fontSize};
   }
 
   @media (max-width: 390px) {
-    width: ${(props) => FriendButtonStyle[props.variant].mobile.width};
-    height: ${(props) => FriendButtonStyle[props.variant].mobile.height};
+    width: ${(props) => FriendButtonStyle[props.$variant].mobile.width};
+    height: ${(props) => FriendButtonStyle[props.$variant].mobile.height};
     border-radius: ${(props) =>
-      FriendButtonStyle[props.variant].mobile.borderRadius};
-    font-size: ${(props) => FriendButtonStyle[props.variant].mobile.fontSize};
+      FriendButtonStyle[props.$variant].mobile.borderRadius};
+    font-size: ${(props) => FriendButtonStyle[props.$variant].mobile.fontSize};
   }
 `;
 
@@ -333,36 +333,36 @@ const RecordButtonStyle = {
 };
 
 export const RecordButton = styled.button<{
-  variant: "moodCancel" | "moodSubmit" | "diaryCancel" | "diarySubmit";
+  $variant: "moodCancel" | "moodSubmit" | "diaryCancel" | "diarySubmit";
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${(props) => RecordButtonStyle[props.variant].default.width};
-  height: ${(props) => RecordButtonStyle[props.variant].default.height};
+  width: ${(props) => RecordButtonStyle[props.$variant].default.width};
+  height: ${(props) => RecordButtonStyle[props.$variant].default.height};
   border-radius: ${(props) =>
-    RecordButtonStyle[props.variant].default.borderRadius};
+    RecordButtonStyle[props.$variant].default.borderRadius};
   background-color: ${(props) =>
-    RecordButtonStyle[props.variant].default.backgroundColor};
+    RecordButtonStyle[props.$variant].default.backgroundColor};
   color: var(--white);
   text-align: center;
-  font-size: ${(props) => RecordButtonStyle[props.variant].default.fontSize};
+  font-size: ${(props) => RecordButtonStyle[props.$variant].default.fontSize};
   font-weight: var(--font-semibold);
 
   @media (max-width: 781px) {
-    width: ${(props) => RecordButtonStyle[props.variant].tablet.width};
-    height: ${(props) => RecordButtonStyle[props.variant].tablet.height};
+    width: ${(props) => RecordButtonStyle[props.$variant].tablet.width};
+    height: ${(props) => RecordButtonStyle[props.$variant].tablet.height};
     border-radius: ${(props) =>
-      RecordButtonStyle[props.variant].tablet.borderRadius};
-    font-size: ${(props) => RecordButtonStyle[props.variant].tablet.fontSize};
+      RecordButtonStyle[props.$variant].tablet.borderRadius};
+    font-size: ${(props) => RecordButtonStyle[props.$variant].tablet.fontSize};
   }
 
   @media (max-width: 390px) {
-    width: ${(props) => RecordButtonStyle[props.variant].mobile.width};
-    height: ${(props) => RecordButtonStyle[props.variant].mobile.height};
+    width: ${(props) => RecordButtonStyle[props.$variant].mobile.width};
+    height: ${(props) => RecordButtonStyle[props.$variant].mobile.height};
     border-radius: ${(props) =>
-      RecordButtonStyle[props.variant].mobile.borderRadius};
-    font-size: ${(props) => RecordButtonStyle[props.variant].mobile.fontSize};
+      RecordButtonStyle[props.$variant].mobile.borderRadius};
+    font-size: ${(props) => RecordButtonStyle[props.$variant].mobile.fontSize};
   }
 `;
 
@@ -426,31 +426,31 @@ const OrangeButtonStyle = {
 };
 
 export const OrangeButton = styled.button<{
-  variant: "membership" | "mailSend" | "confirm" | "signupToLogin";
+  $variant: "membership" | "mailSend" | "confirm" | "signupToLogin";
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${(props) => OrangeButtonStyle[props.variant].default.width};
-  height: ${(props) => OrangeButtonStyle[props.variant].default.height};
+  width: ${(props) => OrangeButtonStyle[props.$variant].default.width};
+  height: ${(props) => OrangeButtonStyle[props.$variant].default.height};
   border-radius: ${(props) =>
-    OrangeButtonStyle[props.variant].default.borderRadius};
+    OrangeButtonStyle[props.$variant].default.borderRadius};
   background-color: var(--main-orange);
   color: var(--white);
   text-align: center;
-  font-size: ${(props) => OrangeButtonStyle[props.variant].default.fontSize};
+  font-size: ${(props) => OrangeButtonStyle[props.$variant].default.fontSize};
   font-weight: var(--font-semibold);
 
   @media (max-width: 390px) {
-    width: ${(props) => OrangeButtonStyle[props.variant].mobile.width};
-    height: ${(props) => OrangeButtonStyle[props.variant].mobile.height};
+    width: ${(props) => OrangeButtonStyle[props.$variant].mobile.width};
+    height: ${(props) => OrangeButtonStyle[props.$variant].mobile.height};
     border-radius: ${(props) =>
-      OrangeButtonStyle[props.variant].mobile.borderRadius};
-    font-size: ${(props) => OrangeButtonStyle[props.variant].mobile.fontSize};
+      OrangeButtonStyle[props.$variant].mobile.borderRadius};
+    font-size: ${(props) => OrangeButtonStyle[props.$variant].mobile.fontSize};
   }
 `;
 
-export const DiaryButton = styled.button<{ variant: "delete" | "modify" }>`
+export const DiaryButton = styled.button<{ $variant: "delete" | "modify" }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -458,7 +458,7 @@ export const DiaryButton = styled.button<{ variant: "delete" | "modify" }>`
   height: 3.25rem;
   border-radius: 0.625rem;
   background-color: ${(props) =>
-    props.variant === "delete" ? "var(--line-basic)" : "var(--orange-button)"};
+    props.$variant === "delete" ? "var(--line-basic)" : "var(--orange-button)"};
   color: var(--white);
   text-align: center;
   font-size: 1.125rem;
@@ -494,7 +494,7 @@ export const CommentButton = styled.button`
 `;
 
 export const ReplyButton = styled.button<{
-  variant: "cancel" | "comment";
+  $variant: "cancel" | "comment";
 }>`
   display: flex;
   align-items: center;
@@ -502,9 +502,9 @@ export const ReplyButton = styled.button<{
   height: 2.625rem;
   border-radius: 0.5rem;
   background-color: ${(props) =>
-    props.variant === "cancel" ? "none" : "var(--comment-button)"};
+    props.$variant === "cancel" ? "none" : "var(--comment-button)"};
   color: ${(props) =>
-    props.variant === "cancel" ? "var(--comment-button)" : "var(--white)"};
+    props.$variant === "cancel" ? "var(--comment-button)" : "var(--white)"};
   font-size: 1rem;
   font-weight: var(--font-semibold);
 
@@ -517,12 +517,12 @@ export const ReplyButton = styled.button<{
 `;
 
 export const DiarySettingButton = styled.button<{
-  variant: "delete" | "bookmark";
+  $variant: "delete" | "bookmark";
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${(props) => (props.variant === "delete" ? "7.75rem" : "9.375rem")};
+  width: ${(props) => (props.$variant === "delete" ? "7.75rem" : "9.375rem")};
   height: 3.75rem;
   border-radius: 0.625rem;
   background-color: var(--orange-button);
@@ -591,18 +591,18 @@ const ProfileButtonStyle = {
 };
 
 export const ProfileButton = styled.button<{
-  variant: "friend" | "diary" | "mood";
+  $variant: "friend" | "diary" | "mood";
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${(props) => ProfileButtonStyle[props.variant].default.width};
-  height: ${(props) => ProfileButtonStyle[props.variant].default.height};
+  width: ${(props) => ProfileButtonStyle[props.$variant].default.width};
+  height: ${(props) => ProfileButtonStyle[props.$variant].default.height};
   border-radius: ${(props) =>
-    ProfileButtonStyle[props.variant].default.borderRadius};
+    ProfileButtonStyle[props.$variant].default.borderRadius};
   background-color: var(--bg-02);
   color: var(--main-text);
-  font-size: ${(props) => ProfileButtonStyle[props.variant].default.fontSize};
+  font-size: ${(props) => ProfileButtonStyle[props.$variant].default.fontSize};
   font-weight: var(--font-medium);
 
   &:hover {
@@ -610,16 +610,16 @@ export const ProfileButton = styled.button<{
   }
 
   @media (max-width: 390px) {
-    width: ${(props) => ProfileButtonStyle[props.variant].mobile.width};
-    height: ${(props) => ProfileButtonStyle[props.variant].mobile.height};
+    width: ${(props) => ProfileButtonStyle[props.$variant].mobile.width};
+    height: ${(props) => ProfileButtonStyle[props.$variant].mobile.height};
     border-radius: ${(props) =>
-      ProfileButtonStyle[props.variant].mobile.borderRadius};
-    font-size: ${(props) => ProfileButtonStyle[props.variant].mobile.fontSize};
+      ProfileButtonStyle[props.$variant].mobile.borderRadius};
+    font-size: ${(props) => ProfileButtonStyle[props.$variant].mobile.fontSize};
   }
 `;
 
 export const MypageButton = styled.button<{
-  variant: "cancel" | "active";
+  $variant: "cancel" | "active";
   disabled?: boolean;
 }>`
   display: flex;
@@ -630,7 +630,7 @@ export const MypageButton = styled.button<{
   border: ${(props) =>
     props.disabled
       ? "none"
-      : `1px solid ${props.variant === "active" ? "var(--main-text)" : "none"}`};
+      : `1px solid ${props.$variant === "active" ? "var(--main-text)" : "none"}`};
   border-radius: 0.5rem;
   background-color: ${(props) =>
     props.disabled ? "var(--disable-button)" : "var(--white)"};
@@ -644,7 +644,7 @@ export const MypageButton = styled.button<{
       if (props.disabled) {
         return "var(--disable-button)"; // Disabled 상태에서는 hover 효과 제거
       }
-      return props.variant === "active"
+      return props.$variant === "active"
         ? "var(--bg-02)" // Active일 때 hover 배경색
         : "var(--bg-02)"; // Cancel일 때 hover 배경색
     }};
@@ -707,36 +707,36 @@ const OrangeLineButtonStyle = {
 };
 
 export const OrangeLineButton = styled.button<{
-  variant: "theme" | "moveToHome" | "modal";
+  $variant: "theme" | "moveToHome" | "modal";
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${(props) => OrangeLineButtonStyle[props.variant].default.width};
-  height: ${(props) => OrangeLineButtonStyle[props.variant].default.height};
+  width: ${(props) => OrangeLineButtonStyle[props.$variant].default.width};
+  height: ${(props) => OrangeLineButtonStyle[props.$variant].default.height};
   border: 1px solid var(--main-orange);
   border-radius: ${(props) =>
-    OrangeLineButtonStyle[props.variant].default.borderRadius};
+    OrangeLineButtonStyle[props.$variant].default.borderRadius};
   background-color: var(--white);
   color: var(--main-text);
   font-size: ${(props) =>
-    OrangeLineButtonStyle[props.variant].default.fontSize};
+    OrangeLineButtonStyle[props.$variant].default.fontSize};
   font-weight: ${(props) =>
-    OrangeLineButtonStyle[props.variant].default.fontWeight};
+    OrangeLineButtonStyle[props.$variant].default.fontWeight};
 
   &:hover {
     background-color: var(--hover-orange);
   }
 
   @media (max-width: 390px) {
-    width: ${(props) => OrangeLineButtonStyle[props.variant].mobile.width};
-    height: ${(props) => OrangeLineButtonStyle[props.variant].mobile.height};
+    width: ${(props) => OrangeLineButtonStyle[props.$variant].mobile.width};
+    height: ${(props) => OrangeLineButtonStyle[props.$variant].mobile.height};
     border-radius: ${(props) =>
-      OrangeLineButtonStyle[props.variant].mobile.borderRadius};
+      OrangeLineButtonStyle[props.$variant].mobile.borderRadius};
     font-size: ${(props) =>
-      OrangeLineButtonStyle[props.variant].mobile.fontSize};
+      OrangeLineButtonStyle[props.$variant].mobile.fontSize};
     font-weight: ${(props) =>
-      OrangeLineButtonStyle[props.variant].mobile.fontWeight};
+      OrangeLineButtonStyle[props.$variant].mobile.fontWeight};
   }
 `;
 
@@ -752,7 +752,7 @@ const FriendTabButtonStyle = {
 };
 
 export const FriendTabButton = styled.button<{
-  variant: "unclicked" | "clicked";
+  $variant: "unclicked" | "clicked";
   isClicked: boolean;
 }>`
   display: flex;
@@ -778,9 +778,9 @@ export const FriendTabButton = styled.button<{
   }
 `;
 
-export const FeedButton = styled.button<{
-  isClicked: boolean;
-}>`
+export const FeedButton = styled.button.withConfig({
+  shouldForwardProp: (prop) => prop !== "isClicked", // `isClicked`가 DOM에 전달되지 않도록 설정
+})<{ isClicked?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/Feed/FeedPage.tsx
+++ b/src/pages/Feed/FeedPage.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { FeedButton } from "@/components/ui/Button";
 import { IoHeart } from "react-icons/io5";
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Pagination } from "swiper/modules";
+import { Autoplay, Pagination } from "swiper/modules";
 import "/node_modules/swiper/swiper.css";
 import { Outlet, useNavigate } from "react-router-dom";
 import GlobalStyles from "@/styles/GlobalStyle";
@@ -135,7 +135,9 @@ const PostContainer = styled.div`
   }
 `;
 
-const PostItem = styled.div<{ noImage?: boolean }>`
+const PostItem = styled.div.withConfig({
+  shouldForwardProp: (prop) => prop !== "noImage", // `noImage`를 DOM으로 전달하지 않음
+})<{ noImage?: boolean }>`
   display: flex;
   flex-direction: column;
   width: 17.25rem;
@@ -152,19 +154,21 @@ const PostItem = styled.div<{ noImage?: boolean }>`
     noImage &&
     css`
       ${PostTitle} {
-        margin-top: 20px;
+        margin-top: 1.25rem;
       }
       ${PostText} {
-        height: 220px;
+        height: 13.75rem;
       }
     `}
 
   @media (max-width: 781px) {
     margin: auto;
+    height: 22rem;
   }
 
   @media (max-width: 390px) {
     width: 11rem;
+    height: 16rem;
     padding-bottom: 0.5rem;
   }
 `;
@@ -213,6 +217,7 @@ const PostText = styled.div`
 const BottomWrap = styled.div`
   display: flex;
   flex-direction: column;
+  margin-top: auto;
   gap: 0.5rem;
 `;
 
@@ -499,7 +504,11 @@ export default function FeedPage() {
                       pagination={{
                         clickable: true,
                       }}
-                      modules={[Pagination]}
+                      modules={[Pagination, Autoplay]}
+                      autoplay={{
+                        delay: 3000, // 3초마다 자동으로 넘김
+                        disableOnInteraction: false, // 사용자가 터치하거나 클릭해도 자동 전환이 계속됨
+                      }}
                       className="mySwiper"
                     >
                       {post.images.map((image, index) => (

--- a/src/pages/Mypage/Diary/DiaryManagement.tsx
+++ b/src/pages/Mypage/Diary/DiaryManagement.tsx
@@ -139,7 +139,7 @@ export default function DiaryManagement() {
         {activeTab === "Mydiary" && (
           <ButtonWrapper>
             <DiarySettingButton
-              variant="delete"
+              $variant="delete"
               style={{ width: "100%", fontSize: "1.375rem" }}
               onClick={() => isModalOpen("deleteModal")}
             >
@@ -150,7 +150,7 @@ export default function DiaryManagement() {
         {activeTab === "Bookmark" && (
           <ButtonWrapper>
             <DiarySettingButton
-              variant="bookmark"
+              $variant="bookmark"
               style={{ width: "100%", fontSize: "1.25rem" }}
               onClick={() => isModalOpen("deleteModal")}
             >

--- a/src/pages/Mypage/DiaryManagement.tsx
+++ b/src/pages/Mypage/DiaryManagement.tsx
@@ -362,10 +362,12 @@ export default function DiaryManagement() {
               </TabButton>
             </Tab>
             {active === "diary" && (
-              <DiarySettingButton variant="delete">삭제하기</DiarySettingButton>
+              <DiarySettingButton $variant="delete">
+                삭제하기
+              </DiarySettingButton>
             )}
             {active === "bookmark" && (
-              <DiarySettingButton variant="bookmark">
+              <DiarySettingButton $variant="bookmark">
                 북마크 해제
               </DiarySettingButton>
             )}

--- a/src/pages/Mypage/PointManagement.tsx
+++ b/src/pages/Mypage/PointManagement.tsx
@@ -299,14 +299,14 @@ const ContextList = styled.div`
   }
 `;
 
-const PointList = styled.div<{ variant: "use" | "save" }>`
+const PointList = styled.div<{ $variant: "use" | "save" }>`
   display: flex;
   width: 26%;
   height: 3rem;
   justify-content: center;
   align-items: center;
   color: ${(props) =>
-    props.variant === "use" ? "var(--point-red)" : "var(--point-blue)"};
+    props.$variant === "use" ? "var(--point-red)" : "var(--point-blue)"};
   text-align: center;
   font-size: 1.25rem;
   font-weight: var(--font-regular);
@@ -536,7 +536,7 @@ export default function PointManagement() {
               currentData.map((item, index) => (
                 <EachList key={index}>
                   <ContextList>{item.description}</ContextList>
-                  <PointList variant={item.points > 0 ? "save" : "use"}>
+                  <PointList $variant={item.points > 0 ? "save" : "use"}>
                     {item.points > 0
                       ? `+ ${new Intl.NumberFormat().format(item.points)} P`
                       : `- ${new Intl.NumberFormat().format(

--- a/src/pages/Mypage/Settings.tsx
+++ b/src/pages/Mypage/Settings.tsx
@@ -821,16 +821,16 @@ export default function Settings() {
               </ProfileBox>
               {!profileShow ? (
                 <SettingButton>
-                  <MypageButton variant="active" onClick={profileSettingClick}>
+                  <MypageButton $variant="active" onClick={profileSettingClick}>
                     설정
                   </MypageButton>
                 </SettingButton>
               ) : (
                 <SaveCancelButton>
-                  <MypageButton variant="cancel" onClick={profileCancelClick}>
+                  <MypageButton $variant="cancel" onClick={profileCancelClick}>
                     취소
                   </MypageButton>
-                  <MypageButton variant="active">저장</MypageButton>
+                  <MypageButton $variant="active">저장</MypageButton>
                 </SaveCancelButton>
               )}
             </ProfileWrap>
@@ -853,7 +853,7 @@ export default function Settings() {
                         disabled
                         style={{ paddingLeft: "0" }}
                       />
-                      <MypageButton variant="active" onClick={passwordChange}>
+                      <MypageButton $variant="active" onClick={passwordChange}>
                         변경
                       </MypageButton>
                     </Password>
@@ -969,11 +969,11 @@ export default function Settings() {
                 <InfoButton>
                   {infoShow && (
                     <InfoSaveCancelButton>
-                      <MypageButton variant="cancel" onClick={infoCancelClick}>
+                      <MypageButton $variant="cancel" onClick={infoCancelClick}>
                         취소
                       </MypageButton>
                       <MypageButton
-                        variant="active"
+                        $variant="active"
                         onClick={() => ChangePassword("changePasswordModal")}
                       >
                         저장
@@ -989,7 +989,7 @@ export default function Settings() {
                       복구되지 않습니다.
                     </span>
                     <MypageButton
-                      variant="active"
+                      $variant="active"
                       onClick={() => DeleteId("deleteIdModal")}
                     >
                       탈퇴

--- a/src/pages/Mypage/Theme/TabMenu/Emoji.tsx
+++ b/src/pages/Mypage/Theme/TabMenu/Emoji.tsx
@@ -321,7 +321,7 @@ export default function Emoji() {
                   <PriceText>300P</PriceText>
                 </PriceBox>
                 <OrangeLineButton
-                  variant="theme"
+                  $variant="theme"
                   onClick={() => isModalOpen("deleteModal")}
                 >
                   구매하기
@@ -345,7 +345,7 @@ export default function Emoji() {
                   가격
                   <PriceText>300P</PriceText>
                 </PriceBox>
-                <OrangeLineButton variant="theme">구매하기</OrangeLineButton>
+                <OrangeLineButton $variant="theme">구매하기</OrangeLineButton>
               </PurchaseBox>
             </ThemeSet>
             <ThemeSet>
@@ -365,7 +365,7 @@ export default function Emoji() {
                   가격
                   <PriceText>300P</PriceText>
                 </PriceBox>
-                <OrangeLineButton variant="theme">구매하기</OrangeLineButton>
+                <OrangeLineButton $variant="theme">구매하기</OrangeLineButton>
               </PurchaseBox>
             </ThemeSet>
             <ThemeSet>
@@ -385,7 +385,7 @@ export default function Emoji() {
                   가격
                   <PriceText>300P</PriceText>
                 </PriceBox>
-                <OrangeLineButton variant="theme">구매하기</OrangeLineButton>
+                <OrangeLineButton $variant="theme">구매하기</OrangeLineButton>
               </PurchaseBox>
             </ThemeSet>
           </ThemeWrapper>

--- a/src/pages/Mypage/Theme/TabMenu/Font.tsx
+++ b/src/pages/Mypage/Theme/TabMenu/Font.tsx
@@ -289,7 +289,7 @@ export default function Font() {
                   <PriceText>300P</PriceText>
                 </PriceBox>
                 <OrangeLineButton
-                  variant="theme"
+                  $variant="theme"
                   onClick={() => isModalOpen("deleteModal")}
                 >
                   구매하기
@@ -313,7 +313,7 @@ export default function Font() {
                   가격
                   <PriceText>300P</PriceText>
                 </PriceBox>
-                <OrangeLineButton variant="theme">구매하기</OrangeLineButton>
+                <OrangeLineButton $variant="theme">구매하기</OrangeLineButton>
               </PurchaseBox>
             </FontSet>
           </FontWrapper>

--- a/src/pages/Mypage/Theme/TabMenu/Own.tsx
+++ b/src/pages/Mypage/Theme/TabMenu/Own.tsx
@@ -240,7 +240,7 @@ export default function Own() {
                 </ImageBox>
               </ThemeBox>
               <ButtonBox>
-                <OrangeLineButton variant="theme">적용하기</OrangeLineButton>
+                <OrangeLineButton $variant="theme">적용하기</OrangeLineButton>
               </ButtonBox>
             </ThemeSet>
             <ThemeSet>
@@ -256,7 +256,7 @@ export default function Own() {
                 </ImageBox>
               </ThemeBox>
               <ButtonBox>
-                <OrangeLineButton variant="theme">적용하기</OrangeLineButton>
+                <OrangeLineButton $variant="theme">적용하기</OrangeLineButton>
               </ButtonBox>
             </ThemeSet>
           </ThemeWrapper>

--- a/src/pages/Mypage/Theme/Theme.tsx
+++ b/src/pages/Mypage/Theme/Theme.tsx
@@ -141,7 +141,7 @@ export default function Theme() {
         {activeTab === "Own" && (
           <ButtonWrapper>
             <DiarySettingButton
-              variant="delete"
+              $variant="delete"
               style={{ width: "100%" }}
               onClick={() => isModalOpen("deleteModal")}
             >

--- a/src/pages/auth/Join.tsx
+++ b/src/pages/auth/Join.tsx
@@ -71,7 +71,7 @@ const JoinTitle = styled.div`
   }
 `;
 
-const LoginButton = styled.button<{ variant: "login" }>`
+const LoginButton = styled.button<{ $variant: "login" }>`
   font-size: 1.25rem;
   color: var(--text-main);
   cursor: pointer;
@@ -296,7 +296,7 @@ const Join: React.FC<AuthType> = () => {
         <LoginLogo to="/Page1" />
         <JoinTitle>
           <Span>이미 회원이신가요?</Span>
-          <LoginButton variant="login" onClick={handleLoing}>
+          <LoginButton $variant="login" onClick={handleLoing}>
             로그인 하기
           </LoginButton>
         </JoinTitle>
@@ -336,7 +336,7 @@ const Join: React.FC<AuthType> = () => {
             )}
           </Error>
           <Button>
-            <OrangeButton variant="membership" type="submit">
+            <OrangeButton $variant="membership" type="submit">
               가입하기
             </OrangeButton>
           </Button>

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -329,7 +329,7 @@ export default function Login() {
           )}
         </Error>
         <Button>
-          <OrangeButton variant="membership" type="submit">
+          <OrangeButton $variant="membership" type="submit">
             로그인 하기
           </OrangeButton>
         </Button>

--- a/src/pages/board/[boardId]/Detail.tsx
+++ b/src/pages/board/[boardId]/Detail.tsx
@@ -770,10 +770,10 @@ export default function BoardDetail() {
         </div>
       </LikeWrap>
       <Button>
-        <DiaryButton variant="delete" onClick={handleDelete}>
+        <DiaryButton $variant="delete" onClick={handleDelete}>
           삭제하기
         </DiaryButton>
-        <DiaryButton variant="modify" onClick={handleEdit}>
+        <DiaryButton $variant="modify" onClick={handleEdit}>
           수정하기
         </DiaryButton>
       </Button>
@@ -818,7 +818,7 @@ export default function BoardDetail() {
           </TextAreaWrap>
           <Button>
             <button>취소</button>
-            <ReplyButton variant="comment">댓글 작성</ReplyButton>
+            <ReplyButton $variant="comment">댓글 작성</ReplyButton>
           </Button>
           <Line></Line>
           <ListArray>

--- a/src/pages/board/new/BoardWrite.tsx
+++ b/src/pages/board/new/BoardWrite.tsx
@@ -588,11 +588,11 @@ const BoardWrite: React.FC<BoarWriteProps> = ({ isEdit }) => {
         <p>오늘 {userInfo ? userInfo.username : "사용자"} 님의 기분은...</p>
       </WriteEmotion>
       <ButtonWrap>
-        <RecordButton variant="moodCancel" onClick={onClickCancel}>
+        <RecordButton $variant="moodCancel" onClick={onClickCancel}>
           취소
         </RecordButton>
         <RecordButton
-          variant="moodSubmit"
+          $variant="moodSubmit"
           onClick={handleSubmit}
           disabled={text < 1} // 1글자 이상 입력
         >

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -63,7 +63,7 @@ const GlobalStyles = createGlobalStyle`
 
   @font-face {
     font-family: 'Pretendard';
-    src: url('/fonts/Pretendard-Regular.woff2') format('woff2'),
+    src: url('/fonts/Pretendard-Regular.woff2?v=2') format('woff2'),
          url('/fonts/Pretendard-Regular.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "incremental": true, // ✅ 추가
+    "tsBuildInfoFile": "./.tscache/tsconfig.node.tsbuildinfo", // ✅ 안전한 경로로 변경
+    // "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2022",
     "lib": ["ES2023"],
     "module": "ESNext",
@@ -17,8 +19,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noFallthroughCasesInSwitch": true
+    // "noUncheckedSideEffectImports": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## 🛠️ **PR 개요**

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 기입 예 -->

- **변경 사항 요약:**
  ```
  피드 페이지 css 수정, 피드 페이지 개발자 도구에서 확인할 수 있는 에러와 경고 일부 해결
  ```

<br />

## 🔍 **주요 변경 사항**

- **추가/수정된 기능:**
  - 피드 페이지 PostItem(게시글)의 이미지 미리보기용 Swiper에 autoplay 적용
  - breakpoint(반응형 사이즈)별 PostItem(게시글)의 height를 고정값으로 지정해 화면 크기에 따라 이미지가 첨부된 게시글과 첨부되지 않은 게시물의 크키가 동일하게 보이도록 css 수정
  - 피드 페이지에서 개발자 도구를 열었을 때 발생하는 에러와 경고를 일부 해결

<br />


## ✅ **체크리스트**
<!-- 해당하는 항목을 체크해주세요. 선택 사항이므로 필요 없는 항목은 지워주세요. -->

- [x] 기능이 정상적으로 동작
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 커밋 메시지 컨벤션에 맞게 작성
- [x] 변경 사항에 대한 테스트 (버그 수정/기능에 대한 테스트)

<br />

## 💥 트러블 슈팅

<!-- 있었던 오류나 발생했던 예외에 대해서 기록해 보세요 -->
<!-- 다음은 예시입니다. 자유롭게 기록해 주세요. -->
<!-- 없다면 지워주세요. -->

- 이미지가 첨부되지 않은 게시글과 첨부된 게시글의 css를 각각 지정해주었는데, 이미지가 첨부되지 않은 게시글에 적용한 코드의 noImage는 React에서 인식하는 기본 속성이 아니므로 DOM에 전달되지 않는 에러 발생
- isClicked prop이 React DOM 요소(button 태그)에 직접 전달되면서 경고 발생
- styled-components가 DOM 요소에 정의되지 않은 속성(variant)을 인식하지 못해 경고 발생

발생한 예외 (1)

```java
// Warning: React does not recognize the noImage prop on a DOM element.
// If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase noimage instead.
// If you accidentally passed it from a parent component, remove it from the DOM element.
```

원인 분석

> React에서는 DOM 요소(div, span 등)에 정의되지 않은 속성(prop)을 전달하면 경고가 발생하는데, React에서 인식하는 기본 속성이 아닌 noImage를 styled-components 또는 일반 JSX 요소에 noImage를 직접 전달


수정한 코드

```jsx
// styled-components의 shouldForwardProp 사용하여 특정 prop이 DOM 요소로 전달되지 않도록 필터링
import styled, { css } from "styled-components";
import { shouldForwardProp } from "@styled-system/should-forward-prop"; // 추가

const PostItem = styled.div.withConfig({
  shouldForwardProp: (prop) => prop !== "noImage", // `noImage`를 DOM으로 전달하지 않음
})<{ noImage?: boolean }>`
  display: flex;
  flex-direction: column;
  width: 17.25rem;
  height: auto;
  background-color: var(--white);
  padding-bottom: 0.75rem;
  border: 1px solid var(--line-diary);
  border-radius: 0.625rem;
  text-align: center;
  gap: 0.75rem;
  box-shadow: 0.125rem 0.125rem 0.5rem 0rem rgba(0, 0, 0, 0.25);

  ${({ noImage }) =>
    noImage &&
    css`
      ${PostTitle} {
        margin-top: 20px;
      }
      ${PostText} {
        height: 220px;
      }
    `}

  @media (max-width: 781px) {
    margin: auto;
  }

  @media (max-width: 390px) {
    width: 11rem;
    padding-bottom: 0.5rem;
  }
`;

```
<br />

발생한 예외 (2)

```java
// Warning: React does not recognize the isClicked prop on a DOM element.
// If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase isclicked instead.
// If you accidentally passed it from a parent component, remove it from the DOM element.
```

원인 분석

> isClicked prop을 styled-components에서 사용하고 있어도, 기본적으로 props는 JSX를 통해 DOM으로 전달되기 때문에 noImage와 동일한 경고가 발생


수정한 코드

```jsx
// noImage 경고와 동일한 방법을 사용하여 해결 (shouldForwardProp을 사용해 isClicked가 DOM으로 전달되지 않도록 필터링)
import styled from "styled-components";

const FeedButton = styled.button.withConfig({
  shouldForwardProp: (prop) => prop !== "isClicked", // `isClicked`가 DOM에 전달되지 않도록 설정
})<{ isClicked?: boolean }>`
  background-color: ${({ isClicked }) => (isClicked ? "gray" : "blue")};
  color: white;
  padding: 10px;
  border-radius: 5px;
  cursor: pointer;
`;


```
<br />

발생한 예외 (3)

```java
// styled-components: it looks like an unknown prop "variant" is being sent through to the DOM, which will likely trigger a React console error.
// If you would like automatic filtering of unknown props, you can opt-into that behavior via <StyleSheetManager shouldForwardProp={...}> (connect an API like @emotion/is-prop-valid) or consider using transient props ($ prefix for automatic filtering.)
```

원인 분석

> noImage, isClicked와 마찬가지로 variant이라는 prop이 styled-components 내부에서 처리되지 않고 DOM 요소(button, div 등)로 전달되면서 DOM 요소에 정의되지 않은 속성(variant)을 인식하지 못해 React가 이를 경고


수정한 코드

```jsx
// $ 접두사(Transient Props)를 사용하여 variant 대신 $variant로 변경 (variant가 styled-components 내부에서만 사용되고, DOM으로 전달되지 않도록 함)
// 모든 Button 태그에 적용
const Button = styled.button<{ $variant?: "primary" | "secondary" }>`
  background-color: ${({ $variant }) => ($variant === "primary" ? "blue" : "gray")};
  color: white;
`;

// 사용할 때도 $variant로 전달
<Button $variant="primary">Click me</Button>


```

<br />

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

게시글 이미지의 swiper에 autoplay와 delay 옵션을 추가해 3초마다 슬라이드가 자동 전환하도록 설정했습니다. 사용자가 수동으로 슬라이드를 조작하더라도 자동 재생이 멈추지 않도록 disableOnInteraction: false 옵션 역시 추가해두었습니다

noImage와 isClicked, variant는 DOM 관련 경고이기 때문에 수정하지 않으면 계속 로그가 쌓이고 유지보수에 불편함이 생긴다고 해서 동일한 방법으로 해결했습니다. 추가로 Failed to decode downloaded font라는 폰트 경고도 발생하는 것을 확인했는데, 이는 폰트가 제대로 표시되고 있고 디자인에 문제가 없음을 확인했기 때문에 우선 그대로 두었습니다!

개발자 도구에 에러 또는 경고가 너무 많이 발생할 경우, 문제의 원인을 확인해보시고 해결 가능 여부와 필수로 해결해야 하는지 여부를 살핀 다음 작업하는 게 좋을 것 같습니다.
